### PR TITLE
Update description docs to reflect actual possible values

### DIFF
--- a/PSCredentialManager.Cmdlet/Cmdlets.cs
+++ b/PSCredentialManager.Cmdlet/Cmdlets.cs
@@ -53,7 +53,7 @@ namespace PSCredentialManager.Cmdlet
         public string Target;
 
         /// <summary>
-        /// <para type="description">Specifies the type of credential to return, possible values are [GENERIC, DOMAIN_PASSWORD, DOMAIN_CERTIFICATE, DOMAIN_VISIBLE_PASSWORD, GENERIC_CERTIFICATE,   DOMAIN_EXTENDED, MAXIMUM, MAXIMUM_EX]</para>
+        /// <para type="description">Specifies the type of credential to return, possible values are [Generic, DomainPassword, DomainCertificate, DomainVisiblePassword, DomainCertificate, DomainExtended, Maximum, MaximumEx]</para>
         /// </summary>
         [Parameter()]
         public CredType Type = CredType.Generic;
@@ -226,13 +226,13 @@ namespace PSCredentialManager.Cmdlet
         public string Comment = "Updated by: " + Environment.UserName + " on: " + DateTime.Now.ToShortDateString();
 
         /// <summary>
-        /// <para type="description">Type of credential to store, possible values are [GENERIC, DOMAIN_PASSWORD, DOMAIN_CERTIFICATE, DOMAIN_VISIBLE_PASSWORD, GENERIC_CERTIFICATE,   DOMAIN_EXTENDED, MAXIMUM, MAXIMUM_EX]</para>
+        /// <para type="description">Type of credential to store, possible values are [Generic, DomainPassword, DomainCertificate, DomainVisiblePassword, DomainCertificate, DomainExtended, Maximum, MaximumEx]</para>
         /// </summary>
         [Parameter()]
         public CredType Type = CredType.Generic;
 
         /// <summary>
-        /// <para type="description">sets the persistence settings of the credential, possible values are [SESSION, LOCAL_MACHINE, ENTERPRISE]</para>
+        /// <para type="description">sets the persistence settings of the credential, possible values are [Session, LocalMachine, Enterprise]</para>
         /// </summary>
         [Parameter()]
         public CredPersist Persist = CredPersist.Session;
@@ -344,7 +344,7 @@ namespace PSCredentialManager.Cmdlet
         public string Target;
 
         /// <summary>
-        /// <para type="description">Specifies the type of credential to be deleted, possible values are [GENERIC, DOMAIN_PASSWORD, DOMAIN_CERTIFICATE, DOMAIN_VISIBLE_PASSWORD, GENERIC_CERTIFICATE,   DOMAIN_EXTENDED, MAXIMUM, MAXIMUM_EX]</para>
+        /// <para type="description">Specifies the type of credential to be deleted, possible values are [Generic, DomainPassword, DomainCertificate, DomainVisiblePassword, DomainCertificate, DomainExtended, Maximum, MaximumEx]</para>
         /// </summary>
         [Parameter()]
         public CredType Type = CredType.Generic;


### PR DESCRIPTION
* Enum values do not contain any underscores and the descriptions shown when you use `Get-Help` are misleading and lead to users experiencing bind parameter errors